### PR TITLE
Added option for loading screen tips

### DIFF
--- a/Holo/Hooks/Menu/LevelLoadingScreenGUI.lua
+++ b/Holo/Hooks/Menu/LevelLoadingScreenGUI.lua
@@ -34,7 +34,7 @@ function LevelLoadingScreenGuiScript:init(scene_gui, res, progress, base_layer)
 		self._back_drop_gui._panel:child("particles_layer"):hide()
 		local panel = self._back_drop_gui:get_new_background_layer()
 		self._back_drop_gui:set_panel_to_saferect(panel)
-		if not self._coords and arg.load_level_data.tip then
+		if not self._coords and arg.load_level_data.tip and not arg.load_level_data.level_data.notips then
 			self._loading_hint = self:_make_loading_hint(panel, arg.load_level_data.tip)
 		end
 		self._indicator = panel:bitmap({

--- a/Holo/Hooks/Setup.lua
+++ b/Holo/Hooks/Setup.lua
@@ -3,6 +3,7 @@ Hooks:PreHook(Setup, "_start_loading_screen", "HoloStartLoadingScreen", function
 		local level_tweak_data = tweak_data.levels[Global.level_data.level_id]
 		if level_tweak_data then  
 			Global.level_data.Holo = Holo:ShouldModify("Menu", "Menu/Loading") 
+			Global.level_data.notips = Holo.Options:GetValue("Extra/DisableLoadingTips")
 			Global.level_data.main_color = Holo:GetColor("Colors/Main")
 			Global.level_data.text_color = Holo:GetColor("TextColors/Menu")
 			Global.level_data.colored_background = Holo.Options:GetValue("Menu/ColoredBackground")

--- a/Holo/Loc/EN.txt
+++ b/Holo/Loc/EN.txt
@@ -110,6 +110,7 @@
    "Holo/TeammateAI" : "AI Teammate",
    "Holo/HudSpacing" : "Hud Spacing",
    "Holo/DisableLobbyVideo" : "Contract Video On Lobby",
+   "Holo/DisableLoadingTips" : "Gameplay Tips On Loading Screen",
    "Holo/Interaction" : "Interaction bar",
    "Holo/Captions" : "Captions",
    "Holo/EnemyHealth" : "Enemy Health",

--- a/Holo/Loc/ES.txt
+++ b/Holo/Loc/ES.txt
@@ -110,6 +110,7 @@
    "Holo/TeammateAI" : "Bots",
    "Holo/HudSpacing" : "Separacion del HUD",
    "Holo/DisableLobbyVideo" : "Video del Contacto en el Lobby",
+   "Holo/DisableLoadingTips" : "Consejos de juego en la pantalla de carga",
    "Holo/Interaction" : "Barra de interaccion",
    "Holo/Captions" : "Subtitulos",
    "Holo/EnemyHealth" : "Salud de enemigos",

--- a/Holo/Loc/FR.txt
+++ b/Holo/Loc/FR.txt
@@ -110,6 +110,7 @@
    "Holo/TeammateAI" : "Coéquipiers controllés par l'ordinateur",
    "Holo/HudSpacing" : "Espacement de l'ATH",
    "Holo/DisableLobbyVideo" : "Vidéo du contrat dans le lobby",
+   "Holo/DisableLoadingTips" : "Astuces de jeu sur l'écran de chargement",
    "Holo/Interaction" : "Cercle d'interaction",
    "Holo/Captions" : "Sous titres",
    "Holo/EnemyHealth" : "Santé des ennemis",

--- a/Holo/Loc/GR.txt
+++ b/Holo/Loc/GR.txt
@@ -101,6 +101,7 @@
 	"Holo/TeammateAI": "AI Teammate",
 	"Holo/HudSpacing": "Hud Abstand",
 	"Holo/DisableLobbyVideo": "Auftrags Video in Lobby",
+	"Holo/DisableLoadingTips" : "Spiel Tipps zum Einlegen von Bildschirm",
 	"Holo/Interaction": "Interaktions Leiste",
 	"Holo/Captions": "Untertitel",
 	"Holo/EnemyHealth": "Gegner Gesundheit",

--- a/Holo/Loc/RU.txt
+++ b/Holo/Loc/RU.txt
@@ -110,6 +110,7 @@
    "Holo/TeammateAI" : "ИИ-Напарник",
    "Holo/HudSpacing" : "Положение Интерфейса",
    "Holo/DisableLobbyVideo" : "Видео С Контрактом В Лобби",
+   "Holo/DisableLoadingTips" : "Геймплей Советы по загрузке экрана",
    "Holo/Interaction" : "Шкала Взаимодействия",
    "Holo/Captions" : "Подписи",
    "Holo/EnemyHealth" : "Здоровье Врага",

--- a/Holo/ModConfig.xml
+++ b/Holo/ModConfig.xml
@@ -112,6 +112,7 @@
             <option type="boolean" default_value="false" name="UpperCaseNames" />      
             <option type="boolean" default_value="true" name="TimerBackground"/>      
             <option type="boolean" default_value="true" beforetext="Disable" name="DisableLobbyVideo" />
+            <option type="boolean" default_value="false" beforetext="Disable" name="DisableLoadingTips" />
             <div name="Positions" />
             <option_group name="Positions" menu="Extra">
                <option type="number" default_value="3" menu_type="combo" items="Positions" name="Assault" />


### PR DESCRIPTION
Adds an option to toggle the showing of the gameplay tips/hints on the loading screen.

The translations may not be very good because I had to rely on Google Translate.