### PR TITLE
Fix U159 CrimeNet crash + sidebar text colors

### DIFF
--- a/Holo/Config.xml
+++ b/Holo/Config.xml
@@ -78,6 +78,7 @@
       <hook source_file="lib/managers/menu/renderers/menunodeupdatesgui" file="Menu/MenuHooks.lua" />
       <hook source_file="lib/managers/menu/menuguicomponentgeneric" file="Menu/MenuGUIComponentGeneric.lua" />
       <hook source_file="lib/managers/menu/menucomponentmanager" file="Menu/MenuComponentManager.lua" />
+      <hook source_file="lib/managers/menu/crimenetsidebargui" file="Menu/CrimeNetSidebarGUI.lua" />
    </Hooks>
    <Options build_menu="false" auto_load="true" save_file="HoloUIConfig.txt">
       <options>

--- a/Holo/Hooks/CrimeNetManager.lua
+++ b/Holo/Hooks/CrimeNetManager.lua
@@ -27,9 +27,6 @@ Holo:Post(CrimeNetGui, "init", function( self, ws, fullscreeen_ws, node )
 		valign = "scale",
 		halign = "scale",
 	})
-	if not no_servers then
-		self._panel:child("filter_button"):set_color(Holo:GetColor("TextColors/Menu"))
-	end
 	self._panel:child("legends_button"):set_color(Holo:GetColor("TextColors/Menu"))
 	self._map_panel:child("map"):set_alpha(Holo.Options:GetValue("ColoredBackground") and 0 or 1)
 end)

--- a/Holo/Hooks/Menu/CrimeNetSidebarGUI.lua
+++ b/Holo/Hooks/Menu/CrimeNetSidebarGUI.lua
@@ -3,6 +3,7 @@ if Holo.Options:GetValue("Menu") then
 
 Holo:Post(CrimeNetSidebarItem, "init", function(self, sidebar, panel, parameters)
 	self:set_color(Holo:GetColor("TextColors/Menu"))
+	self:set_highlight_color(Holo:GetColor("TextColors/Marker"))
 end)
 
 end

--- a/Holo/Hooks/Menu/CrimeNetSidebarGUI.lua
+++ b/Holo/Hooks/Menu/CrimeNetSidebarGUI.lua
@@ -1,0 +1,8 @@
+
+if Holo.Options:GetValue("Menu") then
+
+Holo:Post(CrimeNetSidebarItem, "init", function(self, sidebar, panel, parameters)
+	self:set_color(Holo:GetColor("TextColors/Menu"))
+end)
+
+end


### PR DESCRIPTION
Fixes the Update 159 crash when entering Crime.net and also applies Holo text color settings to the crime.net side bar.

The text color for some reason doesn't work on the Crime Spree button in the sidebar and I have no idea why. I know it is supposed to change color when a Crime spree is active but for some reason its the default color when it isn't.