### PR TITLE
update blackmarketgui

### DIFF
--- a/Holo/Hooks/Menu/BlackmarketGUI.lua
+++ b/Holo/Hooks/Menu/BlackmarketGUI.lua
@@ -90,7 +90,6 @@ function BlackMarketGuiSlotItem:init(panel, data, ...)
 	end
 	self:_init(panel, data, ...)
 	if self._bitmap then
-		self._bitmap:set_color(Color.white)
 		self._bitmap:set_blend_mode("normal")
 	end	
 	if self._lock_bitmap then


### PR DESCRIPTION
deleted self._bitmap:set_color(Color.white) to prevent all colors to turn white once highlighted in new ui